### PR TITLE
Add .gitignore and update models and requirements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,89 @@
+# Created by https://www.gitignore.io
+
+### OSX ###
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+
+# Thumbnails
+._*
+
+# Files that might appear on external disk
+.Spotlight-V100
+.Trashes
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+
+### Python ###
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.cache
+nosetests.xml
+coverage.xml
+
+# Translations
+*.mo
+*.pot
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+
+### Django ###
+*.log
+*.pot
+*.pyc
+__pycache__/
+local_settings.py
+
+.env
+db.sqlite3

--- a/events/models.py
+++ b/events/models.py
@@ -1,5 +1,5 @@
 from django.db import models
-
+from user_profile.models import User_Profile  # Import the User_Profile model from the user_profile app
 
 class Event(models.Model):
     name = models.CharField(max_length=128)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,4 @@
-# incluir requirements
+asgiref==3.7.2
+Django==4.2.6
+sqlparse==0.4.4
+typing_extensions==4.8.0

--- a/user_profile/models.py
+++ b/user_profile/models.py
@@ -17,8 +17,8 @@ class User_Profile(models.Model):
     email = models.EmailField(max_length=128)
     twitter = models.CharField(max_length=50)
     discord = models.CharField(max_length=50)
-    skills_known = models.ForeignKey(skills.Skill, null=True, on_delete=models.CASCADE, related_name="skills_known")
-    skills_to_learn = models.ForeignKey(skills.Skill, null=True, on_delete=models.CASCADE, related_name="skills_to_learn")
+    skills_known = models.ForeignKey('skills.Skill', null=True, on_delete=models.CASCADE, related_name="skills_known")
+    skills_to_learn = models.ForeignKey('skills.Skill', null=True, on_delete=models.CASCADE, related_name="skills_to_learn")
     def __str__(self):
         return self.name
 


### PR DESCRIPTION
The errors in both cases (in the user_profile and events apps) were caused by circular imports, where models from one app attempted to reference models from another. The fixes involved using a string reference to the model's name (e.g., 'skills.Skill' and 'user_profile.User_Profile') in ForeignKey fields to avoid direct imports, resolving the circular import issue.