### PR TITLE
Register the Events app model (Event)

### DIFF
--- a/events/admin.py
+++ b/events/admin.py
@@ -1,3 +1,6 @@
 from django.contrib import admin
+from .models import Event
 
 # Register your models here.
+
+admin.site.register(Event)


### PR DESCRIPTION
I noticed that the model created for the Events app os not registered in admin.py. 